### PR TITLE
3.3.0

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,6 +1,16 @@
 Release notes
 =============
 
+3.2.2
+~~~~~
+
+Minor improvements.
+
+Changes:
+
+- When checking if a token found in a data block while parsing is in the reserved keywords,
+  perform the check case-insensitively.
+
 3.2.1
 ~~~~~
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,12 +1,28 @@
 Release notes
 =============
 
-3.2.2
+3.3.0
 ~~~~~
 
-Minor improvements.
+:py:meth:`pynmrstar.Loop.add_data` has been significantly improved. Adding data to a loop used to be somewhat
+cumbersome, but the function has been updated to support adding data in two new ways which should be significantly
+easier. For one, you can provide a list of dictionaries of tags to add. For example, adding
+``[{'name': 'Jeff', 'location': 'Connecticut'}, {'name': 'Chad', 'location': 'Madison'}]`` to a loop will add two new
+rows, and set the values of ``name`` and ``location`` to the values provided. If there are other tags in the loop, they will
+be assigned null values for the rows corresponding to the tags added.
 
-Changes:
+An additional way to add data, is adding a dictionary of lists, as such (corresponds to the example above):
+``{'name': ['Jon', 'Connecticut'], 'location': ['Chad', 'Madison']}``. This will also create two new rows in the loop
+and assign the values provided.
+
+For both of these, any tags present in the loop for which you do no provide values, or tags for which you provide fewer
+values than other tags, will have the remaining values filled in with null values.
+
+See the function help/documentation (:py:meth:`pynmrstar.Loop.add_data`) for more details. The original functionality
+has been preserved for backwards compatibility, though the new functionality is expected to be easier to use and lead
+to more readable code.
+
+Other minor improvements:
 
 - When checking if a token found in a data block while parsing is in the reserved keywords,
   perform the check case-insensitively.

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -10,6 +10,7 @@ Changes:
 
 - When checking if a token found in a data block while parsing is in the reserved keywords,
   perform the check case-insensitively.
+- Fix a typo in an error message.
 
 3.2.1
 ~~~~~

--- a/pynmrstar/__init__.py
+++ b/pynmrstar/__init__.py
@@ -29,6 +29,7 @@ from pynmrstar.loop import Loop
 from pynmrstar.parser import Parser as _Parser
 from pynmrstar.saveframe import Saveframe
 from pynmrstar.schema import Schema
+import pynmrstar.definitions as definitions
 
 if cnmrstar:
     if "version" not in dir(cnmrstar):

--- a/pynmrstar/_internal.py
+++ b/pynmrstar/_internal.py
@@ -259,7 +259,7 @@ def get_clean_tag_list(item: Union[str, List[str], Tuple[str]]) -> List[Dict[str
         raise ValueError(f'The value you provided was not a string, list, or tuple. Item: {repr(item)}')
 
     try:
-        return [{"formatted": pynmrstar.utils.format_tag(_.lower()), "original": _} for _ in tag_list]
+        return [{"formatted": pynmrstar.utils.format_tag_lc(_), "original": _} for _ in tag_list]
     except AttributeError:
         raise ValueError('Your list or tuple may only contain tag names expressed as strings.')
 

--- a/pynmrstar/_internal.py
+++ b/pynmrstar/_internal.py
@@ -13,7 +13,7 @@ from urllib.request import urlopen, Request
 
 import pynmrstar
 
-__version__: str = "3.2.1"
+__version__: str = "3.3.0"
 min_cnmrstar_version: str = "3.2.0"
 
 # If we have requests, open a session to reuse for the duration of the program run

--- a/pynmrstar/loop.py
+++ b/pynmrstar/loop.py
@@ -29,7 +29,7 @@ class Loop(object):
 
         lc_tags = self._lc_tags
         for tag in to_process:
-            if utils.format_tag(tag).lower() not in lc_tags:
+            if utils.format_tag_lc(tag) not in lc_tags:
                 return False
         return True
 
@@ -161,14 +161,14 @@ class Loop(object):
         If there are 5 rows of data in the loop, you will need to
         assign a list with 5 elements."""
 
-        tag = utils.format_tag(key)
+        tag = utils.format_tag_lc(key)
 
         # Check that their tag is in the loop
-        if tag not in self._tags:
+        if tag not in self._lc_tags:
             raise ValueError(f"Cannot assign to tag '{key}' as it does not exist in this loop.")
 
         # Determine where to assign
-        tag_id = self._tags.index(tag)
+        tag_id = self._lc_tags[tag]
 
         # Make sure they provide a list of the correct length
         if len(self[key]) != len(item):
@@ -489,7 +489,7 @@ class Loop(object):
                 current_row = [None]*len(self._tags)
                 for tag, value in row.items():
                     try:
-                        tag_index = lc_tag_index[utils.format_tag(tag).lower()]
+                        tag_index = lc_tag_index[utils.format_tag_lc(tag)]
                     except KeyError:
                         raise ValueError(f'In row {pos} of your provided data, a tag was supplied which was not'
                                          f" already present in the loop. Invalid tag: '{tag}'")
@@ -852,7 +852,7 @@ class Loop(object):
             if "." in item and utils.format_category(item).lower() != self.category.lower():
                 raise ValueError(f"Cannot fetch data with tag '{item}' because the category does not match the "
                                  f"category of this loop '{self.category}'.")
-            lower_tags[pos] = utils.format_tag(item).lower()
+            lower_tags[pos] = utils.format_tag_lc(item)
 
         # Make a lower case copy of the tags
         tags_lower = [x.lower() for x in self._tags]
@@ -1107,7 +1107,7 @@ class Loop(object):
         iterate through the data and modify it."""
 
         try:
-            return self._lc_tags[utils.format_tag(str(tag_name)).lower()]
+            return self._lc_tags[utils.format_tag_lc(str(tag_name))]
         except KeyError:
             return None
 

--- a/pynmrstar/loop.py
+++ b/pynmrstar/loop.py
@@ -1027,9 +1027,8 @@ class Loop(object):
         iterate through the data and modify it."""
 
         try:
-            lc_col = [x.lower() for x in self._tags]
-            return lc_col.index(utils.format_tag(str(tag_name)).lower())
-        except ValueError:
+            return self._lc_tags[utils.format_tag(str(tag_name)).lower()]
+        except KeyError:
             return None
 
     def validate(self, validate_schema: bool = True, schema: 'Schema' = None,

--- a/pynmrstar/parser.py
+++ b/pynmrstar/parser.py
@@ -191,7 +191,7 @@ class Parser(object):
                                                            "defined. Value: '{self.token}'",
                                                            self.line_number)
 
-                                    if self.token in definitions.RESERVED_KEYWORDS and self.delimiter == " ":
+                                    if self.token.lower() in definitions.RESERVED_KEYWORDS and self.delimiter == " ":
                                         error = "Cannot use keywords as data values unless quoted or semi-colon " \
                                                 "delimited. Perhaps this is a loop that wasn't properly terminated " \
                                                 "with a 'stop_' keyword before the saveframe ended or another loop " \
@@ -249,7 +249,7 @@ class Parser(object):
                     # We are in a saveframe and waiting for the saveframe tag
                     self.get_token()
                     if self.delimiter == " ":
-                        if self.token in definitions.RESERVED_KEYWORDS:
+                        if self.token.lower() in definitions.RESERVED_KEYWORDS:
                             raise ParsingError("Cannot use keywords as data values unless quoted or semi-colon "
                                                f"delimited. Illegal value: '{self.token}'", self.line_number)
                         if self.token.startswith("_"):

--- a/pynmrstar/saveframe.py
+++ b/pynmrstar/saveframe.py
@@ -36,7 +36,7 @@ class Saveframe(object):
                     if item.lower() not in loop_dict:
                         return False
                 else:
-                    if utils.format_tag(item).lower() not in lc_tags:
+                    if utils.format_tag_lc(item) not in lc_tags:
                         return False
             else:
                 return False
@@ -809,7 +809,7 @@ class Saveframe(object):
                 results.extend(each_loop.get_tag(query, whole_tag=whole_tag))
 
         # Check our tags
-        query = utils.format_tag(query).lower()
+        query = utils.format_tag_lc(query)
         if tag_prefix is not None and tag_prefix.lower() == self.tag_prefix.lower():
             for tag in self._tags:
                 if query == tag[0].lower():

--- a/pynmrstar/saveframe.py
+++ b/pynmrstar/saveframe.py
@@ -578,7 +578,7 @@ class Saveframe(object):
             elif self._name != value:
                 raise ValueError('The Sf_framecode tag cannot be different from the saveframe name. Error '
                                  f'occurred in tag {self.tag_prefix}.Sf_framecode with value {value} which '
-                                 f'conflicts with with the saveframe name {self._name}.')
+                                 f'conflicts with the saveframe name {self._name}.')
         self._tags.append(new_tag)
 
     def add_tags(self, tag_list: list, update: bool = False) -> None:

--- a/pynmrstar/schema.py
+++ b/pynmrstar/schema.py
@@ -4,6 +4,7 @@ import os
 import re
 from csv import DictReader
 from datetime import date
+from functools import lru_cache
 from io import StringIO
 from typing import Union, List, Optional, Any, Dict, IO
 
@@ -202,6 +203,7 @@ class Schema(object):
                                     "SFCategory": sf_category, "Tag": tag,
                                     "Dictionary sequence": new_tag_pos}
 
+    @lru_cache(maxsize=1024, typed=True)
     def convert_tag(self, tag: str, value: Any) -> \
             Optional[Union[str, int, decimal.Decimal, date]]:
         """ Converts the provided tag from string to the appropriate

--- a/pynmrstar/utils.py
+++ b/pynmrstar/utils.py
@@ -27,6 +27,7 @@ def diff(entry1: 'entry_mod.Entry', entry2: 'entry_mod.Entry') -> None:
         print(difference)
 
 
+@functools.lru_cache(maxsize=1024)
 def format_category(tag: str) -> str:
     """Adds a '_' to the front of a tag (if not present) and strips out
     anything after a '.'"""
@@ -39,6 +40,7 @@ def format_category(tag: str) -> str:
     return tag
 
 
+@functools.lru_cache(maxsize=1024)
 def format_tag(tag: str) -> str:
     """Strips anything before the '.'"""
 

--- a/pynmrstar/utils.py
+++ b/pynmrstar/utils.py
@@ -49,6 +49,13 @@ def format_tag(tag: str) -> str:
     return tag
 
 
+@functools.lru_cache(maxsize=1024)
+def format_tag_lc(tag: str) -> str:
+    """Strips anything before the '.' and makes the tag lowercase. """
+
+    return format_tag(tag.lower())
+
+
 # noinspection PyDefaultArgument
 def get_schema(passed_schema: 'Schema' = None, _cached_schema: Dict[str, Schema] = {}) -> 'Schema':
     """If passed a schema (not None) it returns it. If passed none,

--- a/release.sh
+++ b/release.sh
@@ -16,7 +16,7 @@ while true; do
     case ${rt} in
         [Tt]* ) python3 -m twine upload --repository testpypi dist/*.tar.gz dist/*.whl --sign; break;;
         [Rr]* ) python3 -m twine upload dist/*.tar.gz dist/*.whl --sign; break;;
-        [Bb]* ) rm dist/*; touch pynmrstar/.nocompile; python3 setup.py sdist; rm -rfv pynmrstar.egg-info; break;;
+        [Bb]* ) rm dist/*; python3 setup.py sdist; rm -rfv pynmrstar.egg-info; break;;
         * ) echo "Please answer r or t.";;
     esac
 done


### PR DESCRIPTION
pynmrstar.Loop.add_data() has been significantly improved. Adding data to a loop used to be somewhat cumbersome, but the function has been updated to support adding data in two new ways which should be significantly easier. For one, you can provide a list of dictionaries of tags to add. For example, adding [{'name': 'Jeff', 'location': 'Connecticut'}, {'name': 'Chad', 'location': 'Madison'}] to a loop will add two new rows, and set the values of name and location to the values provided. If there are other tags in the loop, they will be assigned null values for the rows corresponding to the tags added.

An additional way to add data, is adding a dictionary of lists, as such (corresponds to the example above): {'name': ['Jon', 'Connecticut'], 'location': ['Chad', 'Madison']}. This will also create two new rows in the loop and assign the values provided.

For both of these, any tags present in the loop for which you do no provide values, or tags for which you provide fewer values than other tags, will have the remaining values filled in with null values.

The original functionality has been preserved for backwards compatibility, though the new functionality is expected to be easier to use and lead to more readable code.

Other minor improvements:

- When checking if a token found in a data block while parsing is in the reserved keywords, perform the check case-insensitively.
- Fix a typo in an error message.
